### PR TITLE
Le jeton d'accès peut aussi être fourni dans l'URL

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,11 @@ app.use(cors({
 // Routes to protect with a JSON Web Token
 app.decorateRequest('decodedToken', {})
 const protectedRouteOptions = {
+  schema: {
+    querystring: {
+      access_token: { type: 'string' }
+    }
+  },
   preValidation: [
     verify({ JWT_SECRET }),
     enforceParams('ocId')

--- a/app.test.js
+++ b/app.test.js
@@ -2,7 +2,8 @@ const { server: app, close, ready } = require('.')
 const request = require('supertest')
 const { decode } = require('jsonwebtoken')
 
-const USER_DOC_AUTH_TOKEN = 'Bearer eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJvY0lkIjowLCJ0ZXN0Ijp0cnVlfQ.NL050Bt_jMnQ6WLcqIbmwGJkaDvZ0PIAZdCKTNF_-sSTiTw5cijPGm6TwUSCWEyQUMFvI1_La19TDPXsaemDow'
+const USER_DOC_AUTH_TOKEN = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJvY0lkIjowLCJ0ZXN0Ijp0cnVlfQ.NL050Bt_jMnQ6WLcqIbmwGJkaDvZ0PIAZdCKTNF_-sSTiTw5cijPGm6TwUSCWEyQUMFvI1_La19TDPXsaemDow'
+const USER_DOC_AUTH_HEADER = `Bearer ${USER_DOC_AUTH_TOKEN}`
 
 // start and stop server
 beforeAll(() => ready())
@@ -37,7 +38,7 @@ describe('GET /api/v1/test', () => {
     return request(app)
       .get('/api/v1/test')
       .type('json')
-      .set('Authorization', USER_DOC_AUTH_TOKEN)
+      .set('Authorization', USER_DOC_AUTH_HEADER)
       .then((response) => {
         expect(response.status).toBe(200)
         expect(response.header['content-type']).toBe('application/json; charset=utf-8')
@@ -92,7 +93,7 @@ describe('GET /api/v1/summary', () => {
     return request(app)
       .get('/api/v1/summary')
       .type('json')
-      .set('Authorization', USER_DOC_AUTH_TOKEN)
+      .set('Authorization', USER_DOC_AUTH_HEADER)
       .then((response) => {
         expect(response.status).toBe(200)
         expect(response.header['content-type']).toBe('application/json; charset=utf-8')
@@ -122,7 +123,7 @@ describe('GET /api/v1/parcels', () => {
     return request(app)
       .get('/api/v1/parcels')
       .type('json')
-      .set('Authorization', USER_DOC_AUTH_TOKEN)
+      .set('Authorization', USER_DOC_AUTH_HEADER)
       .then((response) => {
         expect(response.status).toBe(200)
         expect(response.header['content-type']).toBe('application/json; charset=utf-8')
@@ -145,7 +146,7 @@ describe('GET /api/v1/parcels/operator/:numero-bio', () => {
     return request(app)
       .get('/api/v1/parcels/operator/11')
       .type('json')
-      .set('Authorization', USER_DOC_AUTH_TOKEN)
+      .set('Authorization', USER_DOC_AUTH_HEADER)
       .then((response) => {
         expect(response.status).toBe(200)
         expect(response.header['content-type']).toBe('application/json; charset=utf-8')
@@ -166,7 +167,7 @@ describe('GET /api/v1/parcels/operator/:numero-bio', () => {
     return request(app)
       .get('/api/v1/parcels/operator/666')
       .type('json')
-      .set('Authorization', USER_DOC_AUTH_TOKEN)
+      .set('Authorization', USER_DOC_AUTH_HEADER)
       .then((response) => {
         expect(response.status).toBe(200)
         expect(response.header['content-type']).toBe('application/json; charset=utf-8')

--- a/app.test.js
+++ b/app.test.js
@@ -33,11 +33,23 @@ describe('GET /api/v1/test', () => {
       })
   })
 
-  test('responds well', () => {
+  test('responds well with an Authorization header', () => {
     return request(app)
       .get('/api/v1/test')
       .type('json')
       .set('Authorization', USER_DOC_AUTH_TOKEN)
+      .then((response) => {
+        expect(response.status).toBe(200)
+        expect(response.header['content-type']).toBe('application/json; charset=utf-8')
+        expect(response.body).toHaveProperty('test', 'OK')
+      })
+  })
+
+  test('responds well with an access_token query string', () => {
+    return request(app)
+      .get('/api/v1/test')
+      .query({ access_token: USER_DOC_AUTH_TOKEN })
+      .type('json')
       .then((response) => {
         expect(response.status).toBe(200)
         expect(response.header['content-type']).toBe('application/json; charset=utf-8')

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -16,7 +16,7 @@ const verify = ({ JWT_SECRET }) => {
     let token
 
     try {
-      token = (request.headers.authorization || '').replace(/^Bearer /, '')
+      token = (request.headers.authorization || request.query.access_token || '').replace(/^Bearer /, '')
       reply.header('X-Api-Version', apiVersion)
       request.decodedToken = verifyToken(token, JWT_SECRET)
       done()


### PR DESCRIPTION
Pratique quand on veut ajouter un layer GeoJSON sans configurer les entêtes d'un client HTTP.

refs entrepreneur-interet-general/CartoBio-Presentation#54