### PR TITLE
Expose `nom`, `denominationCourante` et `gerant`

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ const { featureCollection } = require('@turf/helpers')
 const { version: apiVersion } = require('./package.json')
 const JWT_SECRET = Buffer.from(process.env.CARTOBIO_JWT_SECRET, 'base64')
 
-const { verify, track, enforceParams } = require('./lib/middlewares.js')
+const { verify, track: _track, enforceParams } = require('./lib/middlewares.js')
 const { getOperatorParcels, getOperatorSummary } = require('./lib/parcels.js')
 const { fetchAuthToken, fetchUserProfile, getCertificationBodyForPacage } = require('./lib/providers/agence-bio.js')
 const { updateOperator } = require('./lib/providers/cartobio.js')
@@ -35,12 +35,15 @@ const { PORT, HOST, SENTRY_DSN, NODE_ENV } = env
 const reportErrors = SENTRY_DSN && NODE_ENV === 'production'
 
 // Sentry error reporting setup
-if (SENTRY_DSN) {
+if (reportErrors) {
   Sentry.init({
     dsn: SENTRY_DSN,
     release: 'cartobio-api@' + process.env.npm_package_version
   })
 }
+
+// Track events in Matomo in production only
+const track = reportErrors ? _track : () => {}
 
 // Configure server
 app.register(require('fastify-cors'), {

--- a/lib/parcels.js
+++ b/lib/parcels.js
@@ -32,8 +32,11 @@ async function getOperatorSummary ({ ocId, numeroBio }) {
       const { nom, denominationCourante, dateEngagement, dateMaj } = operator
       const { code: departement, centroid } = getDepartementFromId(operator.departementId)
 
+      const mainName = denominationCourante || nom || gerant || `Opérateur·ice n°${numeroBio}`
+
       return point(centroid, {
-        nom: denominationCourante || nom || gerant || '',
+        nom: mainName,
+        identity: { nom, denominationCourante, gerant },
         numerobio: numeroBio,
         pacage: numeroPacage,
         date_engagement: dateEngagement,


### PR DESCRIPTION
Ça aidera à rechercher plus finement dans les résultats.

En bonus : les évènements Matomo/Sentry sont activés uniquement en production.